### PR TITLE
Preserve array type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/) and adheres to [semver](http://semver.org/).
 
+## v0.2.0
+### Added
+- Memory of array types (encode as an `Int32Array` and it'll decode as an `Int32Array`).
+
 ## v0.1.1
 ### Fixed
 - Handling of Node `Buffer` instances (they were being stringified).

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ const int16Array = new Int16Array(int8Array.buffer)
 More details about typed arrays can be [found here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
 
 ## Roadmap
-- Preserve binary type (if you encode an `Int32Array`, don't decode with `Uint8Array`).
 - Add support for custom `Buffer` interfaces (`json.Buffer = require('buffer/')`).
 - Deduplicate nested buffers (`encode({ buff1: buffer, buff2: buffer })` will contain `buffer` twice).
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -78,7 +78,7 @@ describe('bin-json', () => {
   });
 
   it('does not replace broken pointers', () => {
-    const data = { [json.SECRET_KEY]: ['b', 0] };
+    const data = { [json.SECRET_KEY]: [0, 0] };
 
     const result = json.decode(json.encode(data));
 
@@ -92,7 +92,7 @@ describe('bin-json', () => {
     const data = {
       binary,
       something: {
-        [json.SECRET_KEY]: [8, 0],
+        [json.SECRET_KEY]: [0, 8],
       },
     };
 
@@ -127,5 +127,53 @@ describe('bin-json', () => {
     expect(value.buffer.type).toBeFalsy();
     expect(value.buffer.data).toBeFalsy();
     expect(value.buffer).toEqual(expect.any(Uint8Array));
+  });
+
+  it('preserves the array type', () => {
+    const buffer = json.encode({
+      f32: new Float32Array(1),
+      f64: new Float64Array(1),
+      ui32: new Uint32Array(1),
+      i32: new Int32Array(1),
+      ui16: new Uint16Array(1),
+      i16: new Int16Array(1),
+      ui8: new Uint8Array(1),
+      i8: new Int8Array(1),
+    });
+
+    const data = json.decode(buffer);
+
+    expect(data.f32).toEqual(expect.any(Float32Array));
+    expect(data.f64).toEqual(expect.any(Float64Array));
+    expect(data.ui32).toEqual(expect.any(Uint32Array));
+    expect(data.i32).toEqual(expect.any(Int32Array));
+    expect(data.ui16).toEqual(expect.any(Uint16Array));
+    expect(data.i16).toEqual(expect.any(Int16Array));
+    expect(data.ui8).toEqual(expect.any(Uint8Array));
+    expect(data.i8).toEqual(expect.any(Int8Array));
+  });
+
+  it('preserves data in custom array types', () => {
+    const buffer = json.encode({
+      f32: new Float32Array(1).fill(32.5),
+      f64: new Float64Array(1).fill(64.5),
+      ui32: new Uint32Array(1).fill(32),
+      i32: new Int32Array(1).fill(32),
+      ui16: new Uint16Array(1).fill(16),
+      i16: new Int16Array(1).fill(16),
+      ui8: new Uint8Array(1).fill(8),
+      i8: new Int8Array(1).fill(8),
+    });
+
+    const data = json.decode(buffer);
+
+    expect([...data.f32]).toEqual([32.5]);
+    expect([...data.f64]).toEqual([64.5]);
+    expect([...data.ui32]).toEqual([32]);
+    expect([...data.i32]).toEqual([32]);
+    expect([...data.ui16]).toEqual([16]);
+    expect([...data.i16]).toEqual([16]);
+    expect([...data.ui8]).toEqual([8]);
+    expect([...data.i8]).toEqual([8]);
   });
 });


### PR DESCRIPTION
If you serialize binary using an `Float32Array`, it'll deserialize as an
`Float32Array` (or whatever other type of typed array you're using).