### PR TITLE
Throw an error if decoding invalid data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > This changelog adopts the [keep-a-changelog style](http://keepachangelog.com/en/0.3.0/) and adheres to [semver](http://semver.org/).
 
+## v0.3.1
+### Changed
+- Minor change: now `json.decode(...)` throws a helpful message if you give it an invalid value.
+
 ## v0.3.0
 ### Added
 - `json.use(Buffer)` option which automatically converts typed arrays into buffer instances of your choosing.

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -9,6 +9,21 @@ describe('bin-json', () => {
     json.use(null);
   });
 
+  it('throws if you decode a non-buffer', () => {
+    expect(() => json.decode('value')).toThrow(/string/);
+    expect(() => json.decode(5)).toThrow(/number/);
+    expect(() => json.decode(null)).toThrow(/null/);
+    expect(() => json.decode(undefined)).toThrow(/undefined/);
+
+    expect(() => json.decode(json.encode(10))).not.toThrow();
+  });
+
+  it('throws a helpful message if given a stringified ArrayBuffer', () => {
+    const fail = () => json.decode('[object ArrayBuffer]');
+
+    expect(fail).toThrow(/arraybuffer/i);
+  });
+
   it('encodes to an ArrayBuffer', () => {
     const buffer = json.encode('data');
 

--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,24 @@ const deserialize = (buffers) => (key, value) => {
  * @return {Mixed} - The JSON data, binary values included :tada:
  */
 exports.decode = (buffer) => {
+  const typeName = typeof buffer;
+  const isObject = typeName === 'object' && !!buffer;
+
+  // Do some validation.
+  if (buffer === '[object ArrayBuffer]') {
+    throw new TypeError(
+      'Hmmm, bin-json.decode(...) was given "[object ArrayBuffer]".\n' +
+      'Double check that your encoded data is being handled correctly.'
+    );
+  }
+
+  if (!isObject) {
+    const type = typeName === 'object' ? String(buffer) : typeName;
+    throw new TypeError(
+      `bin-json.decode() expects a buffer, but was given "${type}".`
+    );
+  }
+
   const parsed = unpack(buffer);
   const buffers = parsed.slice(0, -1);
   const deserializer = deserialize(buffers);


### PR DESCRIPTION
If `json.decode(...)` is given a bad value, it'll throw a helpful error.
This doesn't handle cases like bad buffer headers or invalid json data,
just streamlines a common pitfall (node stdlib handles typed arrays
badly).

Fixes #2